### PR TITLE
chore: remove redundant inner nav from site headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: fix-nav
+
+fix-nav:
+	python tools/remove_inner_nav.py
+	git status -sb

--- a/about.html
+++ b/about.html
@@ -19,14 +19,6 @@
   <header class="site-header">
     <div class="site-header-inner">
       <h1 class="site-title">About</h1>
-      <nav aria-label="Primary site navigation">
-        <ul class="site-nav">
-          <li><a href="about.html" class="nav-active" aria-current="page">About</a></li>
-          <li><a href="teaching.html">Teaching</a></li>
-          <li><a href="projects.html">Projects</a></li>
-          <li><a href="notes.html">Notes</a></li>
-        </ul>
-      </nav>
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -19,14 +19,6 @@
   <header class="site-header">
     <div class="site-header-inner">
       <h1 class="site-title">Welcome to My Professional Homepage</h1>
-      <nav aria-label="Primary site navigation">
-        <ul class="site-nav">
-          <li><a href="about.html">About</a></li>
-          <li><a href="teaching.html">Teaching</a></li>
-          <li><a href="projects.html">Projects</a></li>
-          <li><a href="notes.html">Notes</a></li>
-        </ul>
-      </nav>
     </div>
   </header>
   <main class="site-main" id="content">

--- a/notes.html
+++ b/notes.html
@@ -19,14 +19,6 @@
   <header class="site-header">
     <div class="site-header-inner">
       <h1 class="site-title">Notes</h1>
-      <nav aria-label="Primary site navigation">
-        <ul class="site-nav">
-          <li><a href="about.html">About</a></li>
-          <li><a href="teaching.html">Teaching</a></li>
-          <li><a href="projects.html">Projects</a></li>
-          <li><a href="notes.html" class="nav-active" aria-current="page">Notes</a></li>
-        </ul>
-      </nav>
     </div>
   </header>
   <main class="site-main" id="content">

--- a/notes/vim-linux.html
+++ b/notes/vim-linux.html
@@ -31,14 +31,6 @@
   <header class="site-header">
     <div class="site-header-inner">
       <h1 class="site-title">Notes</h1>
-      <nav aria-label="Primary site navigation">
-        <ul class="site-nav">
-          <li><a href="../about.html">About</a></li>
-          <li><a href="../teaching.html">Teaching</a></li>
-          <li><a href="../projects.html">Projects</a></li>
-          <li><a href="../notes.html" class="nav-active" aria-current="page">Notes</a></li>
-        </ul>
-      </nav>
     </div>
   </header>
 

--- a/projects.html
+++ b/projects.html
@@ -19,14 +19,6 @@
   <header class="site-header">
     <div class="site-header-inner">
       <h1 class="site-title">Projects</h1>
-      <nav aria-label="Primary site navigation">
-        <ul class="site-nav">
-          <li><a href="about.html">About</a></li>
-          <li><a href="teaching.html">Teaching</a></li>
-          <li><a href="projects.html" class="nav-active" aria-current="page">Projects</a></li>
-          <li><a href="notes.html">Notes</a></li>
-        </ul>
-      </nav>
     </div>
   </header>
 

--- a/teaching.html
+++ b/teaching.html
@@ -19,14 +19,6 @@
   <header class="site-header">
     <div class="site-header-inner">
       <h1 class="site-title">Teaching</h1>
-      <nav aria-label="Primary site navigation">
-        <ul class="site-nav">
-          <li><a href="about.html">About</a></li>
-          <li><a href="teaching.html" class="nav-active" aria-current="page">Teaching</a></li>
-          <li><a href="projects.html">Projects</a></li>
-          <li><a href="notes.html">Notes</a></li>
-        </ul>
-      </nav>
     </div>
   </header>
 

--- a/tools/remove_inner_nav.py
+++ b/tools/remove_inner_nav.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Remove redundant <nav> elements inside <header class="site-header"> blocks.
+
+Usage:
+    python tools/remove_inner_nav.py [--dry-run]
+
+The script recursively scans the repository for HTML files, removing any
+<nav> elements that are descendants of a <header class="site-header"> element.
+When run with --dry-run, it only reports the files that would be modified.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+EXCLUDE_DIRS = {".git", "node_modules"}
+HEADER_PATTERN = re.compile(r"(<header\b[^>]*>)(.*?)(</header>)", re.IGNORECASE | re.DOTALL)
+CLASS_PATTERN = re.compile(r'class\s*=\s*(".*?"|\'.*?\')', re.IGNORECASE | re.DOTALL)
+NAV_PATTERN = re.compile(r"<nav\b[^>]*>.*?</nav>", re.IGNORECASE | re.DOTALL)
+BLANK_LINE_PATTERN = re.compile(r"\n[ \t]+\n")
+MULTI_BLANK_PATTERN = re.compile(r"\n{3,}")
+
+
+def iter_html_files(root: Path) -> Iterable[Path]:
+    """Yield all .html files under *root*, skipping excluded directories."""
+    for html_file in root.rglob("*.html"):
+        try:
+            rel_parts = html_file.relative_to(root).parts
+        except ValueError:
+            continue
+        if any(part in EXCLUDE_DIRS for part in rel_parts):
+            continue
+        yield html_file
+
+
+def has_site_header_class(tag_text: str) -> bool:
+    """Return True if tag_text contains a class attribute with 'site-header'."""
+    for match in CLASS_PATTERN.finditer(tag_text):
+        value = match.group(1)[1:-1]
+        classes = {cls for cls in re.split(r"\s+", value.strip()) if cls}
+        if "site-header" in classes:
+            return True
+    return False
+
+
+def clean_blank_lines(content: str) -> str:
+    content = BLANK_LINE_PATTERN.sub("\n", content)
+    content = MULTI_BLANK_PATTERN.sub("\n\n", content)
+    return content
+
+
+def remove_navs_from_header(match: re.Match[str]) -> Tuple[str, bool]:
+    opening, content, closing = match.groups()
+    if not has_site_header_class(opening):
+        return match.group(0), False
+
+    new_content, count = NAV_PATTERN.subn("", content)
+    if count == 0:
+        return match.group(0), False
+
+    new_content = clean_blank_lines(new_content)
+    return f"{opening}{new_content}{closing}", True
+
+
+def remove_inner_navs(html: str) -> Tuple[str, bool]:
+    changed = False
+    result = []
+    last_index = 0
+
+    for header_match in HEADER_PATTERN.finditer(html):
+        start, end = header_match.span()
+        replacement, header_changed = remove_navs_from_header(header_match)
+        if header_changed:
+            changed = True
+        result.append(html[last_index:start])
+        result.append(replacement)
+        last_index = end
+
+    result.append(html[last_index:])
+    new_html = "".join(result)
+    return new_html, changed
+
+
+def process_file(path: Path, dry_run: bool) -> bool:
+    original = path.read_text(encoding="utf-8")
+    updated, changed = remove_inner_navs(original)
+
+    if not changed:
+        return False
+
+    if not dry_run:
+        path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show which files would be modified without writing changes.",
+    )
+    args = parser.parse_args(argv)
+
+    script_path = Path(__file__).resolve()
+    repo_root = script_path.parents[1]
+
+    changed_files: List[Path] = []
+    for html_file in iter_html_files(repo_root):
+        if process_file(html_file, args.dry_run):
+            changed_files.append(html_file)
+
+    if changed_files:
+        heading = "Files that would be modified:" if args.dry_run else "Modified files:"
+        print(heading)
+        for path in sorted(changed_files):
+            print(f" - {path.relative_to(repo_root)}")
+    else:
+        print("No changes needed.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a repository script that removes navigation blocks nested inside `header.site-header`
- provide a `make fix-nav` helper that runs the cleanup and reports git status
- run the tool across the site to drop redundant per-page navigation markup

## Testing
- python tools/remove_inner_nav.py --dry-run
- python tools/remove_inner_nav.py
- make fix-nav

------
https://chatgpt.com/codex/tasks/task_e_690bd355fd988330b2543a6cfe9e4ce9